### PR TITLE
fix quamash setup in async_utils

### DIFF
--- a/pyrpl/async_utils.py
+++ b/pyrpl/async_utils.py
@@ -2,25 +2,31 @@
 This file contains a number of methods for asynchronous operations.
 """
 import logging
-from qtpy import QtCore, QtWidgets
-from timeit import default_timer
 import sys
+from timeit import default_timer
+
+from qtpy import QtCore, QtWidgets
+
 logger = logging.getLogger(name=__name__)
 
 from . import APP  # APP is only created once at the startup of PyRPL
+
 MAIN_THREAD = APP.thread()
 
 try:
-    from asyncio import Future, ensure_future, CancelledError, \
-        set_event_loop, TimeoutError
+    from asyncio import CancelledError, Future, TimeoutError
+    from asyncio import events as asyncio_events
+    from asyncio import set_event_loop
 except ImportError:  # this occurs in python 2.7
     logger.debug("asyncio not found, we will use concurrent.futures "
                   "instead of python 3.5 Futures.")
-    from concurrent.futures import Future, CancelledError, TimeoutError
+    from concurrent.futures import CancelledError, Future, TimeoutError
 else:
     import quamash
-    set_event_loop(quamash.QEventLoop())
     LOOP = quamash.QEventLoop()
+    set_event_loop(LOOP)
+    # set currently running event loop to support asyncio.get_event_loop()
+    asyncio_events._set_running_loop(LOOP)
 
 
 class MainThreadTimer(QtCore.QTimer):


### PR DESCRIPTION
- Only create a single instance of quamash.QEventLoop

- Set the currently running event loop to support asyncio.get_event_loop().
  Using this code await asyncio.sleep(0.5) works in python 3.8 without
  explicitly passing in the event loop - which is deprecated and set to be
  removed in python 3.10. (Idea from https://github.com/gmarull/asyncqt/pull/13)

`quamash` is also generally unmaintained. [asyncqt](https://github.com/TheGreatCabbage/asyncqt) is a fork of a fork and looks active.