### PR TITLE
fixed a bug in MonitorClient._writes (redpitaya_client.py)

### DIFF
--- a/pyrpl/redpitaya_client.py
+++ b/pyrpl/redpitaya_client.py
@@ -133,8 +133,13 @@ class MonitorClient(object):
                                          (addr >> 16) & 0xFF,
                                          (addr >> 24) & 0xFF]))
         # send header+body
-        self.socket.send(header +
-                         np.array(values, dtype=np.uint32).tobytes())
+        message = header + np.array(values, dtype=np.uint32).tobytes()
+        numsent = 0
+        while numsent < len(message):
+            sent = self.socket.send(message[numsent:])
+            numsent += sent
+            if sent == 0:
+                raise RuntimeError("socket connection broken")
         if self.socket.recv(8) == header:  # check for in-sync transmission
             return True  # indicate successful write
         else:  # error handling


### PR DESCRIPTION
causes incomplete array transmission and subsequent timeout errors during socket communication on a Raspberry Pi and potentially other systems as well