### PR TITLE
Added support for loading FPGA for ecosystem version 2.0 and higher.

### DIFF
--- a/pyrpl/redpitaya.py
+++ b/pyrpl/redpitaya.py
@@ -317,9 +317,15 @@ class RedPitaya(object):
         self.end()
         self.ssh.ask('killall nginx')
         self.ssh.ask('systemctl stop redpitaya_nginx') # for 0.94 and higher
-        self.ssh.ask('cat '
-                 + os.path.join(self.parameters['serverdirname'], self.parameters['serverbinfilename'])
-                 + ' > //dev//xdevcfg')
+        sleep(3) # sleep after stopping service
+        result = self.ssh.ask('cat /root/.version')
+        if result.find('2.') != -1:
+            self.ssh.ask('/opt/redpitaya/sbin/overlay.sh pyrpl')
+            sleep(1)
+        else:
+            self.ssh.ask('cat '
+                + os.path.join(self.parameters['serverdirname'], self.parameters['serverbinfilename'])
+                + ' > //dev//xdevcfg')
         sleep(self.parameters['delay'])
         self.ssh.ask('rm -f '+ os.path.join(self.parameters['serverdirname'], self.parameters['serverbinfilename']))
         self.ssh.ask("nginx -p //opt//www//")


### PR DESCRIPTION
Hi.
Added checking the operating system version. If it is version 2.0, then the FPGA is booted via the new boot mechanism (xdevcfg is deprecated and no longer used in Vivado versions newer than 2020).
We also moved the FPGA source code to the RedPitaya repository, otherwise we would have to add a lot of code to your repository in order to be compatible with the current architecture.
FPGA is now pre-built and will be included in ecosystem updates.